### PR TITLE
SMIE hotfix

### DIFF
--- a/faust-mode.el
+++ b/faust-mode.el
@@ -194,6 +194,7 @@
     (modify-syntax-entry ?\n "> b" st)
     (modify-syntax-entry ?\^m "> b" st)
     (modify-syntax-entry ?\\ "." st)
+    (modify-syntax-entry ?\' "_" st)
     st)
   "Syntax table for `faust-mode'.")
 

--- a/faust-mode.el
+++ b/faust-mode.el
@@ -209,9 +209,9 @@
 ;; agraef: Preliminary Faust SMIE support. Due to restrictions in SMIE, the
 ;; grammar given here is just a minimal version of the Faust grammar for the
 ;; sole purpose of defining proper indentation. We also offer two variables
-;; faust-indent and faust-outdent-with which let you customize some aspects of
-;; the indentation, and it's possible to turn off SMIE altogether if it's not
-;; working for you, see below for details.
+;; faust-indent and faust-outdent-blocks which let you customize some aspects
+;; of the indentation, and it's possible to turn off SMIE altogether if it's
+;; not working for you, see below for details.
 
 (defgroup faust nil
   "Major mode for editing Faust code."
@@ -251,16 +251,19 @@ created Faust buffers."
 ;;     foo = bar;
 ;;   };
 ;;
-;; I think that this looks better, so this is the default right now, but you
-;; can change the indentation style of these constructs by customizing the
-;; following `faust-outdent-with' variable (set it to `nil' if you prefer to
-;; indent relative to the right-hand side of a definition).
+;; I think that this looks better and it also matches the indentation style
+;; used in the Faust Quick Reference, so this is the default right now.
+;; But if you prefer the former style, you can get that by setting the
+;; `faust-outdent-blocks' variable to `nil'. Also note that even if the latter
+;; style is used, you can make sure that a block expression is interpreted as
+;; part of the right-hand side (and indented accordingly) by just enclosing
+;; the entire block expression in parentheses.
 
-(defun faust-make-smie-grammar (outdent-with)
+(defun faust-make-smie-grammar (outdent-blocks)
   (smie-prec2->grammar
    (smie-bnf->prec2
     `((id)
-      ,(if outdent-with
+      ,(if outdent-blocks
 	   '(def ("declare" id)
 		 (id "=" exp)
 		 (id "=" exp "with" "{" defs "}")
@@ -279,7 +282,7 @@ created Faust buffers."
     '((assoc ";"))
     '((nonassoc "=") (assoc "~") (assoc ",") (assoc ":") (assoc "<:" ":>")))))
 
-(defcustom faust-outdent-with t
+(defcustom faust-outdent-blocks t
   "Configure indentation of Faust block constructs.
 Non-nil means to indent the `with' and `letrec' constructs
 relative to the definition, not the right-hand side expression.
@@ -290,11 +293,11 @@ existing Faust buffer, you have to run \\[faust-smie-reset] in
 that buffer."
   :type 'boolean
   :set (lambda (_symbol value)
-	 (setq-default faust-outdent-with value)
+	 (setq-default faust-outdent-blocks value)
 	 (setq faust-smie-grammar (faust-make-smie-grammar value)))
   :group 'faust)
 
-(defvar faust-smie-grammar (faust-make-smie-grammar faust-outdent-with))
+(defvar faust-smie-grammar (faust-make-smie-grammar faust-outdent-blocks))
 
 (defun faust-smie-reset ()
   "Reset the SMIE setup in the current Faust buffer."

--- a/faust-mode.el
+++ b/faust-mode.el
@@ -187,14 +187,22 @@
     (,faust-regexp-faust-delimiters . font-lock-reference-face)
     (,faust-regexp-faust-numbers . font-lock-negation-char-face)))
 
+;; agraef: We derive the syntax table from C mode here since it's much closer
+;; to Faust's lexical syntax than the default syntax table which seems to be
+;; geared more towards Lisp. That way we get comment syntax for free and only
+;; need to fix up \ and ' which are just ordinary punction in Faust.
+(require 'cc-mode)
 (defvar faust-mode-syntax-table
-  (let ((st (make-syntax-table)))
-    (modify-syntax-entry ?/  ". 124b" st)
-    (modify-syntax-entry ?*  ". 23" st)
-    (modify-syntax-entry ?\n "> b" st)
-    (modify-syntax-entry ?\^m "> b" st)
+  (let ((st (make-syntax-table c-mode-syntax-table)))
     (modify-syntax-entry ?\\ "." st)
-    (modify-syntax-entry ?\' "_" st)
+    ;; XXXFIXME: ' should really be punctuation, but for reasons unknown to
+    ;; mankind this completely throws off SMIE's automatic indentation
+    ;; engine. Adding ' to the SMIE grammar or indentation rules doesn't help
+    ;; with that either. We work around this by just declaring ' a prefix
+    ;; character for now (word or symbol constituent works, too, but has other
+    ;; unwanted implications). If anyone has a better idea on how to fix this,
+    ;; please let me know! -agraef
+    (modify-syntax-entry ?\' "'" st)
     st)
   "Syntax table for `faust-mode'.")
 


### PR DESCRIPTION
Fix wrong syntax for the quote symbol (1-sample delay in Faust). Also tidy up the syntax table by basing it on the c-mode syntax table which is much closer to lexical Faust syntax.