### PR TITLE
Keyword fixes

### DIFF
--- a/faust-mode.el
+++ b/faust-mode.el
@@ -174,7 +174,7 @@
   "All Faust keywords and functions.")
 
 (defvar faust-mode-ac-source
-  '((candidates . faust-keywords-lib)))
+  '((candidates . faust-keywords-all)))
 
 (defvar faust-regexp-keywords-function (regexp-opt faust-keywords-functions 'words))
 (defvar faust-regexp-keywords-statement (regexp-opt faust-keywords-statements 'words))

--- a/faust-mode.el
+++ b/faust-mode.el
@@ -160,6 +160,19 @@
    faust-keywords-lib-vaeffect)
   "All the Faust library function keywords.")
 
+(defvar faust-keywords-misc
+  (append
+   faust-keywords-statements
+   faust-keywords-functions
+   faust-keywords-ui)
+  "Miscellaneous Faust keywords and built-in functions.")
+
+(defvar faust-keywords-all
+  (append
+   faust-keywords-misc
+   faust-keywords-lib)
+  "All Faust keywords and functions.")
+
 (defvar faust-mode-ac-source
   '((candidates . faust-keywords-lib)))
 

--- a/faust-mode.el
+++ b/faust-mode.el
@@ -73,9 +73,6 @@
 (defconst faust-keywords-functions
   '("mem" "prefix" "int" "float" "rdtable" "rwtable" "select2" "select3" "ffunction" "fconstant" "fvariable" "attach" "acos" "asin" "atan" "atan2" "cos" "sin" "tan" "exp" "log" "log10" "pow" "sqrt" "abs" "min" "max" "fmod" "remainder" "floor" "ceil" "rint"))
 
-(defconst faust-keywords-math
-  '("mem" "prefix" "int" "float" "rdtable" "rwtable" "select2" "select3" "ffunction" "fconstant" "fvariable" "attach" "acos" "asin" "atan" "atan2" "cos" "sin" "tan" "exp" "log" "log10" "pow" "sqrt" "abs" "min" "max" "fmod" "remainder" "floor" "ceil" "rint"))
-
 (defconst faust-keywords-ui
   '("button" "checkbox" "vslider" "hslider" "nentry" "vgroup" "hgroup" "tgroup" "vbargraph" "hbargraph"))
 


### PR DESCRIPTION
This does away with the redundant and unused `faust-keywords-math` list, adds `faust-keywords-all` which has everything and the kitchen sink, and uses that with auto-complete instead of just `faust-keywords-lib`.